### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -1039,7 +1039,7 @@ function spawnWrapper(params, tmpfiles, binary, callback) {
     var spawnSSL = function() {
         spawnOpenSSL(params, binary, function(err, code, stdout, stderr) {
             toUnlink.forEach(function(filePath) {
-                fs.unlink(filePath);
+                fs.unlinkSync(filePath);
             });
             callback(err, code, stdout, stderr);
         });


### PR DESCRIPTION
```
DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

From upstream: https://github.com/Dexus/pem/commit/34f3fe6dcc330f030459e80849d80c983e93381f