### PR TITLE
Further fix deprecation warnings

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -75,7 +75,7 @@ function createPrivateKey(keyBitsize, options, callback) {
 
     execOpenSSL(params, 'RSA PRIVATE KEY', function(error, key) {
         if(clientKeyPassword) {
-            fs.unlink(clientKeyPassword);
+            fs.unlinkSync(clientKeyPassword);
         }
         if (error) {
             return callback(error);
@@ -220,7 +220,7 @@ function createCSR(options, callback) {
 
     execOpenSSL(params, 'CERTIFICATE REQUEST', tmpfiles, function(error, data) {
         if (passwordFilePath) {
-            fs.unlink(passwordFilePath);
+            fs.unlinkSync(passwordFilePath);
         }
         if (error) {
             return callback(error);


### PR DESCRIPTION
Related: #1

```
Uncaught TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
```